### PR TITLE
Add merge key and merge strategy to Helm parameter list

### DIFF
--- a/schema/argo_all_k8s_kustomize_schema.json
+++ b/schema/argo_all_k8s_kustomize_schema.json
@@ -961,7 +961,9 @@
                     "items": {
                         "default": {},
                         "$ref": "#/definitions/io.argoproj.argocd.v1alpha1.HelmParameter"
-                    }
+                    },
+                    "x-kubernetes-patch-merge-key": "name",
+                    "x-kubernetes-patch-strategy": "merge"
                 },
                 "passCredentials": {
                     "description": "PassCredentials pass credentials to all domains (Helm's --pass-credentials)",

--- a/schema/argo_cd_kustomize_schema.json
+++ b/schema/argo_cd_kustomize_schema.json
@@ -961,7 +961,9 @@
                     "items": {
                         "default": {},
                         "$ref": "#/definitions/io.argoproj.argocd.v1alpha1.HelmParameter"
-                    }
+                    },
+                    "x-kubernetes-patch-merge-key": "name",
+                    "x-kubernetes-patch-strategy": "merge"
                 },
                 "passCredentials": {
                     "description": "PassCredentials pass credentials to all domains (Helm's --pass-credentials)",


### PR DESCRIPTION
We need this in order to merge Helm parameters across a multi-level `kustomize` hierarchy of `Applications` and `ApplicationSets`. As this seems to be a pretty standard use case, we would like to fix this upstream.