### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/scheduled_updates.yaml
+++ b/.github/workflows/scheduled_updates.yaml
@@ -22,7 +22,7 @@ jobs:
           make gen-openapi-schema
       - name: Get current date
         id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d-%s')"
+        run: echo "date=$(date +'%Y-%m-%d-%s')" >> $GITHUB_OUTPUT
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: Updated schema files


### PR DESCRIPTION
## Description

Resolve  #6 

Update `.github/workflows/scheduled_updates.yaml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow file that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
run: echo "::set-output name=date::$(date +'%Y-%m-%d-%s')"
```

**TO-BE**

```yaml
run: echo "date=$(date +'%Y-%m-%d-%s')" >> $GITHUB_OUTPUT
```